### PR TITLE
fix: 패키지 이동

### DIFF
--- a/src/main/java/org/book/commerce/bookcommerce/config/security/JwtTokenProvider.java
+++ b/src/main/java/org/book/commerce/bookcommerce/config/security/JwtTokenProvider.java
@@ -5,10 +5,8 @@ import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.book.commerce.bookcommerce.repository.UsersRepository;
 import org.book.commerce.bookcommerce.repository.entity.Users;
-import org.book.commerce.bookcommerce.service.exception.AuthService;
-import org.book.commerce.bookcommerce.service.exception.CustomUserDetailService;
+import org.book.commerce.bookcommerce.service.CustomUserDetailService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -20,7 +18,6 @@ import org.springframework.util.StringUtils;
 
 import java.util.Base64;
 import java.util.Date;
-import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/org/book/commerce/bookcommerce/service/AuthService.java
+++ b/src/main/java/org/book/commerce/bookcommerce/service/AuthService.java
@@ -1,4 +1,4 @@
-package org.book.commerce.bookcommerce.service.exception;
+package org.book.commerce.bookcommerce.service;
 
 
 import jakarta.mail.MessagingException;
@@ -7,12 +7,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.book.commerce.bookcommerce.config.AESUtil;
-import org.book.commerce.bookcommerce.config.RedisConfig;
 import org.book.commerce.bookcommerce.config.RedisUtil;
 import org.book.commerce.bookcommerce.config.security.JwtTokenProvider;
-import org.book.commerce.bookcommerce.controller.dto.CommonResponseDto;
-import org.book.commerce.bookcommerce.controller.dto.LoginInfo;
-import org.book.commerce.bookcommerce.controller.dto.SignupInfo;
+import org.book.commerce.bookcommerce.web.dto.CommonResponseDto;
+import org.book.commerce.bookcommerce.web.dto.LoginInfo;
+import org.book.commerce.bookcommerce.web.dto.SignupInfo;
 import org.book.commerce.bookcommerce.repository.UsersRepository;
 import org.book.commerce.bookcommerce.repository.entity.Role;
 import org.book.commerce.bookcommerce.repository.entity.Users;
@@ -22,7 +21,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/org/book/commerce/bookcommerce/service/CustomUserDetailService.java
+++ b/src/main/java/org/book/commerce/bookcommerce/service/CustomUserDetailService.java
@@ -1,4 +1,4 @@
-package org.book.commerce.bookcommerce.service.exception;
+package org.book.commerce.bookcommerce.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;

--- a/src/main/java/org/book/commerce/bookcommerce/service/ImageUploadService.java
+++ b/src/main/java/org/book/commerce/bookcommerce/service/ImageUploadService.java
@@ -1,4 +1,4 @@
-package org.book.commerce.bookcommerce.service.exception;
+package org.book.commerce.bookcommerce.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/org/book/commerce/bookcommerce/service/MailService.java
+++ b/src/main/java/org/book/commerce/bookcommerce/service/MailService.java
@@ -1,4 +1,4 @@
-package org.book.commerce.bookcommerce.service.exception;
+package org.book.commerce.bookcommerce.service;
 
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;

--- a/src/main/java/org/book/commerce/bookcommerce/service/ProductService.java
+++ b/src/main/java/org/book/commerce/bookcommerce/service/ProductService.java
@@ -1,18 +1,18 @@
-package org.book.commerce.bookcommerce.service.exception;
+package org.book.commerce.bookcommerce.service;
 
 import lombok.RequiredArgsConstructor;
-import org.book.commerce.bookcommerce.controller.dto.*;
 import org.book.commerce.bookcommerce.repository.ImageRepository;
 import org.book.commerce.bookcommerce.repository.ProductRepository;
 import org.book.commerce.bookcommerce.repository.entity.CustomUserDetails;
 import org.book.commerce.bookcommerce.repository.entity.Image;
 import org.book.commerce.bookcommerce.repository.entity.Product;
-import org.book.commerce.bookcommerce.service.exception.mapper.ImageMapper;
-import org.book.commerce.bookcommerce.service.exception.mapper.ProductMapper;
+import org.book.commerce.bookcommerce.service.mapper.ImageMapper;
+import org.book.commerce.bookcommerce.service.mapper.ProductMapper;
+import org.book.commerce.bookcommerce.web.controller.dto.*;
+import org.book.commerce.bookcommerce.web.dto.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 

--- a/src/main/java/org/book/commerce/bookcommerce/service/UserService.java
+++ b/src/main/java/org/book/commerce/bookcommerce/service/UserService.java
@@ -1,9 +1,9 @@
-package org.book.commerce.bookcommerce.service.exception;
+package org.book.commerce.bookcommerce.service;
 
 import lombok.RequiredArgsConstructor;
 import org.book.commerce.bookcommerce.config.AESUtil;
-import org.book.commerce.bookcommerce.controller.dto.MyPageDto;
-import org.book.commerce.bookcommerce.controller.dto.UpdateInfo;
+import org.book.commerce.bookcommerce.web.dto.MyPageDto;
+import org.book.commerce.bookcommerce.web.dto.UpdateInfo;
 import org.book.commerce.bookcommerce.repository.UsersRepository;
 import org.book.commerce.bookcommerce.repository.entity.Users;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/org/book/commerce/bookcommerce/service/mapper/ImageMapper.java
+++ b/src/main/java/org/book/commerce/bookcommerce/service/mapper/ImageMapper.java
@@ -1,6 +1,6 @@
-package org.book.commerce.bookcommerce.service.exception.mapper;
+package org.book.commerce.bookcommerce.service.mapper;
 
-import org.book.commerce.bookcommerce.controller.dto.ImgList;
+import org.book.commerce.bookcommerce.web.dto.ImgList;
 import org.book.commerce.bookcommerce.repository.entity.Image;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;

--- a/src/main/java/org/book/commerce/bookcommerce/service/mapper/ProductMapper.java
+++ b/src/main/java/org/book/commerce/bookcommerce/service/mapper/ProductMapper.java
@@ -1,7 +1,7 @@
-package org.book.commerce.bookcommerce.service.exception.mapper;
+package org.book.commerce.bookcommerce.service.mapper;
 
 
-import org.book.commerce.bookcommerce.controller.dto.AllProductList;
+import org.book.commerce.bookcommerce.web.dto.AllProductList;
 import org.book.commerce.bookcommerce.repository.entity.Product;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;

--- a/src/main/java/org/book/commerce/bookcommerce/web/controller/AuthController.java
+++ b/src/main/java/org/book/commerce/bookcommerce/web/controller/AuthController.java
@@ -1,4 +1,4 @@
-package org.book.commerce.bookcommerce.controller;
+package org.book.commerce.bookcommerce.web.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -6,10 +6,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.book.commerce.bookcommerce.config.security.JwtTokenProvider;
-import org.book.commerce.bookcommerce.controller.dto.CommonResponseDto;
-import org.book.commerce.bookcommerce.controller.dto.LoginInfo;
-import org.book.commerce.bookcommerce.controller.dto.SignupInfo;
-import org.book.commerce.bookcommerce.service.exception.AuthService;
+import org.book.commerce.bookcommerce.web.dto.CommonResponseDto;
+import org.book.commerce.bookcommerce.web.dto.LoginInfo;
+import org.book.commerce.bookcommerce.web.dto.SignupInfo;
+import org.book.commerce.bookcommerce.service.AuthService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/org/book/commerce/bookcommerce/web/controller/ProductController.java
+++ b/src/main/java/org/book/commerce/bookcommerce/web/controller/ProductController.java
@@ -1,24 +1,17 @@
-package org.book.commerce.bookcommerce.controller;
+package org.book.commerce.bookcommerce.web.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.book.commerce.bookcommerce.controller.dto.AddProductDto;
-import org.book.commerce.bookcommerce.controller.dto.AllProductList;
-import org.book.commerce.bookcommerce.controller.dto.EditProduct;
-import org.book.commerce.bookcommerce.controller.dto.ProductDetail;
+import org.book.commerce.bookcommerce.web.dto.AddProductDto;
+import org.book.commerce.bookcommerce.web.dto.AllProductList;
+import org.book.commerce.bookcommerce.web.dto.EditProduct;
+import org.book.commerce.bookcommerce.web.dto.ProductDetail;
 import org.book.commerce.bookcommerce.repository.entity.CustomUserDetails;
-import org.book.commerce.bookcommerce.repository.entity.Product;
-import org.book.commerce.bookcommerce.service.exception.CustomUserDetailService;
-import org.book.commerce.bookcommerce.service.exception.ProductService;
-import org.springframework.data.domain.Page;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
+import org.book.commerce.bookcommerce.service.ProductService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.awt.print.Pageable;
 import java.util.List;
 
 @RequiredArgsConstructor

--- a/src/main/java/org/book/commerce/bookcommerce/web/controller/UserController.java
+++ b/src/main/java/org/book/commerce/bookcommerce/web/controller/UserController.java
@@ -1,10 +1,10 @@
-package org.book.commerce.bookcommerce.controller;
+package org.book.commerce.bookcommerce.web.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.book.commerce.bookcommerce.controller.dto.MyPageDto;
-import org.book.commerce.bookcommerce.controller.dto.UpdateInfo;
+import org.book.commerce.bookcommerce.web.dto.MyPageDto;
+import org.book.commerce.bookcommerce.web.dto.UpdateInfo;
 import org.book.commerce.bookcommerce.repository.entity.CustomUserDetails;
-import org.book.commerce.bookcommerce.service.exception.UserService;
+import org.book.commerce.bookcommerce.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;

--- a/src/main/java/org/book/commerce/bookcommerce/web/dto/AddProductDto.java
+++ b/src/main/java/org/book/commerce/bookcommerce/web/dto/AddProductDto.java
@@ -1,4 +1,4 @@
-package org.book.commerce.bookcommerce.controller.dto;
+package org.book.commerce.bookcommerce.web.dto;
 
 import lombok.Getter;
 

--- a/src/main/java/org/book/commerce/bookcommerce/web/dto/AllProductList.java
+++ b/src/main/java/org/book/commerce/bookcommerce/web/dto/AllProductList.java
@@ -1,4 +1,4 @@
-package org.book.commerce.bookcommerce.controller.dto;
+package org.book.commerce.bookcommerce.web.dto;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/org/book/commerce/bookcommerce/web/dto/CommonResponseDto.java
+++ b/src/main/java/org/book/commerce/bookcommerce/web/dto/CommonResponseDto.java
@@ -1,4 +1,4 @@
-package org.book.commerce.bookcommerce.controller.dto;
+package org.book.commerce.bookcommerce.web.dto;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/org/book/commerce/bookcommerce/web/dto/EditProduct.java
+++ b/src/main/java/org/book/commerce/bookcommerce/web/dto/EditProduct.java
@@ -1,4 +1,4 @@
-package org.book.commerce.bookcommerce.controller.dto;
+package org.book.commerce.bookcommerce.web.dto;
 
 import lombok.Getter;
 

--- a/src/main/java/org/book/commerce/bookcommerce/web/dto/ImgList.java
+++ b/src/main/java/org/book/commerce/bookcommerce/web/dto/ImgList.java
@@ -1,4 +1,4 @@
-package org.book.commerce.bookcommerce.controller.dto;
+package org.book.commerce.bookcommerce.web.dto;
 
 import lombok.Setter;
 

--- a/src/main/java/org/book/commerce/bookcommerce/web/dto/LoginInfo.java
+++ b/src/main/java/org/book/commerce/bookcommerce/web/dto/LoginInfo.java
@@ -1,4 +1,4 @@
-package org.book.commerce.bookcommerce.controller.dto;
+package org.book.commerce.bookcommerce.web.dto;
 
 import lombok.Getter;
 

--- a/src/main/java/org/book/commerce/bookcommerce/web/dto/MyPageDto.java
+++ b/src/main/java/org/book/commerce/bookcommerce/web/dto/MyPageDto.java
@@ -1,4 +1,4 @@
-package org.book.commerce.bookcommerce.controller.dto;
+package org.book.commerce.bookcommerce.web.dto;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/org/book/commerce/bookcommerce/web/dto/ProductDetail.java
+++ b/src/main/java/org/book/commerce/bookcommerce/web/dto/ProductDetail.java
@@ -1,4 +1,4 @@
-package org.book.commerce.bookcommerce.controller.dto;
+package org.book.commerce.bookcommerce.web.dto;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/org/book/commerce/bookcommerce/web/dto/SignupInfo.java
+++ b/src/main/java/org/book/commerce/bookcommerce/web/dto/SignupInfo.java
@@ -1,4 +1,4 @@
-package org.book.commerce.bookcommerce.controller.dto;
+package org.book.commerce.bookcommerce.web.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/org/book/commerce/bookcommerce/web/dto/UpdateInfo.java
+++ b/src/main/java/org/book/commerce/bookcommerce/web/dto/UpdateInfo.java
@@ -1,4 +1,4 @@
-package org.book.commerce.bookcommerce.controller.dto;
+package org.book.commerce.bookcommerce.web.dto;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;


### PR DESCRIPTION
- controller 패키지의 경로를 web 패키지 하위로 이동.
- service 패키지 하위 exception패키지에 있던 service 클래스들을 service 패키지 하위로 이동
- exception 패키지 하위에 있던 mapper패키지를 service 하위로 이동