### PR TITLE
feat: 스케줄러 기능 구현

### DIFF
--- a/src/main/java/org/book/commerce/bookcommerce/BookCommerceApplication.java
+++ b/src/main/java/org/book/commerce/bookcommerce/BookCommerceApplication.java
@@ -1,11 +1,14 @@
 package org.book.commerce.bookcommerce;
 
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling // 스케쥴러 기능 활성화
 public class BookCommerceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/book/commerce/bookcommerce/common/config/Scheduler.java
+++ b/src/main/java/org/book/commerce/bookcommerce/common/config/Scheduler.java
@@ -1,0 +1,28 @@
+package org.book.commerce.bookcommerce.common.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.book.commerce.bookcommerce.domain.order.domain.Order;
+import org.book.commerce.bookcommerce.domain.order.domain.OrderStatus;
+import org.book.commerce.bookcommerce.domain.order.service.OrderService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class Scheduler {
+    private final OrderService orderService;
+
+    @Scheduled(cron="0 */5 * * * *") // 30분에 한번씩
+    @Transactional
+    public void exceedDay(){
+        log.info("스케쥴러 작동중: 현재시각 : "+ LocalDateTime.now());
+        orderService.exceedOrderDay();
+    }
+
+}

--- a/src/main/java/org/book/commerce/bookcommerce/common/entity/BaseEntity.java
+++ b/src/main/java/org/book/commerce/bookcommerce/common/entity/BaseEntity.java
@@ -11,6 +11,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 @Setter
@@ -20,9 +21,9 @@ import java.util.Date;
 public class BaseEntity {
     @CreatedDate
     @Column(updatable = false)
-    private Date createdAt;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private Date updatedAt;
+    private LocalDateTime updatedAt;
 
 }

--- a/src/main/java/org/book/commerce/bookcommerce/domain/order/dto/OrderlistDto.java
+++ b/src/main/java/org/book/commerce/bookcommerce/domain/order/dto/OrderlistDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.book.commerce.bookcommerce.domain.order.domain.OrderStatus;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
 
@@ -15,7 +16,7 @@ import java.util.List;
 public class OrderlistDto {
 
     private Long orderId;
-    private Date orderDate; // 주문 날짜
+    private LocalDateTime orderDate; // 주문 날짜
     private OrderStatus orderStatus;
 
     private List<OrderProductListDto> orderProductList; // 주문한 아이템 목록

--- a/src/main/java/org/book/commerce/bookcommerce/domain/order/repository/OrderRepository.java
+++ b/src/main/java/org/book/commerce/bookcommerce/domain/order/repository/OrderRepository.java
@@ -1,6 +1,7 @@
 package org.book.commerce.bookcommerce.domain.order.repository;
 
 import org.book.commerce.bookcommerce.domain.order.domain.Order;
+import org.book.commerce.bookcommerce.domain.order.domain.OrderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +10,6 @@ import java.util.List;
 @Repository
 public interface OrderRepository extends JpaRepository<Order,Long> {
     List<Order> findAllByUserEmail(String userEmail);
+
+    List<Order> findAllByStatus(OrderStatus status);
 }


### PR DESCRIPTION
- 스케줄러를 활용하여 30분에 한번씩 order 테이블을 확인하여, 주문완료로 바뀐지 24시간이 지난 필드는 배송중으로, 배송중->배송완료, 취소신청->취소완료 등으로 상태변경되도록 설정


**❓ 이후 생각해 볼 것**
1. 스케줄러가 아닌 스프링 배치와 Quartz를 활용하는 것중 무엇이 더 유리할까? 무엇이 더 내 프로젝트의 특징과 맞고, 성능에 도움이 될까 고민
2. 현재는 30분마다 작동하도록했지만, 해당 메서드에서 모든 주문목록을 가져와서 비교하는 만큼, 주문목록이 늘어날수록 성능저하가 우려 => 하루에 한번만 작동하도록 하는 건 어떨지 ? 예를들어, 오전 9시에 실행되어 현재날짜보다 하루전에 상태가 바뀐 필드들을 다음상태로 바꿔주는 것. (배송중=>배송완료) 