### PR TITLE
feat: Imglist엔티티 @Getter추가

### DIFF
--- a/src/main/java/org/book/commerce/bookcommerce/domain/product/dto/ImgList.java
+++ b/src/main/java/org/book/commerce/bookcommerce/domain/product/dto/ImgList.java
@@ -1,7 +1,9 @@
 package org.book.commerce.bookcommerce.domain.product.dto;
 
+import lombok.Getter;
 import lombok.Setter;
 
+@Getter
 @Setter
 public class ImgList {
 


### PR DESCRIPTION
- 물품상세정보 조회시 Imglist엔티티에 대한 직렬화 에러발생하여 @Getter 추가하여 에러 해결